### PR TITLE
Updated dependencies

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,9 +41,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        run: cargo build --features diesel-uuid
+        run: cargo build --features diesel-uuid,serde
 
       - name: Test
-        run: cargo nextest run --features diesel-uuid
+        run: cargo nextest run --features diesel-uuid,serde
         env:
           PG_DATABASE_URL: postgres://postgres:postgres@localhost/postgres

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "quodlibetor/uuid-b64", branch = "master" }
 base64 = "0.22.0"
 diesel-derive-newtype = { version = "0.1", optional = true }
 diesel = { version = "1.0", features = ["postgres", "uuid"], optional = true }
-error-chain = "0.11.0"
+error-chain = "0.12.0"
 inlinable_string = { version = "0.1.0", features = ["serde"] }
 serde = { version = "1.0.15", optional = true }
 # Diesel 1.1.1 doesn't support 0.6.1 yet

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,11 @@ edition = "2021"
 travis-ci = { repository = "quodlibetor/uuid-b64", branch = "master" }
 
 [dependencies]
-base64 = "0.8"
+base64 = "0.22.0"
 diesel-derive-newtype = { version = "0.1", optional = true }
 diesel = { version = "1.0", features = ["postgres", "uuid"], optional = true }
 error-chain = "0.11.0"
 inlinable_string = { version = "0.1.0", features = ["serde"] }
-lazy_static = "0.2.9"
 serde = { version = "1.0.15", optional = true }
 # Diesel 1.1.1 doesn't support 0.6.1 yet
 uuid = { version = ">=0.5.1,<0.7.0", features = ["v4", "use_std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0/MIT"
 readme = "README.md"
 categories = ["encoding", "value-formatting"]
 repository = "https://github.com/quodlibetor/uuid-b64"
+edition = "2021"
 
 [badges]
 travis-ci = { repository = "quodlibetor/uuid-b64", branch = "master" }
@@ -23,7 +24,7 @@ serde = { version = "1.0.15", optional = true }
 uuid = { version = ">=0.5.1,<0.7.0", features = ["v4", "use_std"] }
 
 [features]
-default-features = ["serde"]
+default = ["serde"]
 diesel-uuid = ["diesel-derive-newtype", "diesel"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Brandon W Maister <quodlibetor@gmail.com>"]
 name = "uuid-b64"
 description = "Base64 encoding for UUIDs"
-version = "0.1.1"
+version = "0.2.0"
 license = "Apache-2.0/MIT"
 readme = "README.md"
 categories = ["encoding", "value-formatting"]
@@ -14,19 +14,20 @@ travis-ci = { repository = "quodlibetor/uuid-b64", branch = "master" }
 
 [dependencies]
 base64 = "0.22.0"
-diesel-derive-newtype = { version = "0.1", optional = true }
-diesel = { version = "1.0", features = ["postgres", "uuid"], optional = true }
+diesel-derive-newtype = { version = "2.1.0", optional = true }
+diesel = { version = "2.2.0", features = ["postgres", "uuid"], optional = true }
 error-chain = "0.12.0"
-inlinable_string = { version = "0.1.0", features = ["serde"] }
+inlinable_string = { version = "0.1.0", default-features = false }
 serde = { version = "1.0.15", optional = true }
-# Diesel 1.1.1 doesn't support 0.6.1 yet
-uuid = { version = ">=0.5.1,<0.7.0", features = ["v4", "use_std"] }
+uuid = { version = "1.8.0", features = ["v4"] }
 
 [features]
-default = ["serde"]
-diesel-uuid = ["diesel-derive-newtype", "diesel"]
+default = []
+serde = ["dep:serde", "inlinable_string/serde"]
+diesel-uuid = ["dep:diesel-derive-newtype", "dep:diesel"]
+diesel = ["diesel-uuid"]
 
 [dev-dependencies]
 serde_json = "1.0"
 serde_derive = "1.0"
-diesel = { version = "1.0", features = ["postgres", "uuid"] }
+diesel = { version = "2.2.0", features = ["postgres", "uuid"] }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,5 @@
+use error_chain::error_chain;
+
 error_chain! {
     errors {
         ParseError(t: String) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,25 +88,6 @@
 //! * `diesel-uuid` enables integration with Diesel's UUID support, this is
 //!   only tested on postgres, PRs welcome for other DBs.
 
-#[cfg(feature = "diesel")]
-#[macro_use]
-extern crate diesel_derive_newtype;
-#[macro_use]
-extern crate error_chain;
-extern crate inlinable_string;
-extern crate uuid;
-
-#[cfg(all(test, feature = "diesel-uuid"))]
-#[macro_use]
-extern crate diesel;
-#[cfg(all(test, feature = "diesel-uuid"))]
-#[cfg(all(test, feature = "serde"))]
-#[macro_use]
-extern crate serde_derive;
-#[cfg(all(test, feature = "serde"))]
-#[macro_use]
-extern crate serde_json;
-
 use std::convert::From;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::str::FromStr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ use base64::{CharacterSet, Config, LineWrap};
 use base64::display::Base64Display;
 use inlinable_string::inline_string::InlineString;
 
-use errors::{ErrorKind, ResultExt};
+use crate::errors::{ErrorKind, ResultExt};
 
 mod errors;
 #[cfg(feature = "serde")]

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -52,7 +52,7 @@ mod tests {
 
     #[test]
     fn ser_de() {
-        let uuid = Uuid::from_fields(0xff, 2, 3, &[1, 2, 3, 4, 5, 6, 7, 8]).unwrap();
+        let uuid = Uuid::from_fields(0xff, 2, 3, &[1, 2, 3, 4, 5, 6, 7, 8]);
         let my_id = UuidB64::from(uuid);
 
         let json = json!({ "myid": my_id }).to_string();

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -45,6 +45,7 @@ impl<'de> Visitor<'de> for UuidB64Visitor {
 #[cfg(test)]
 mod tests {
     use serde_derive::Deserialize;
+    use serde_json::json;
     use uuid::Uuid;
 
     use crate::UuidB64;

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -2,8 +2,8 @@ extern crate serde;
 
 use std::fmt::{Formatter, Result as FmtResult};
 
-use self::serde::ser::{Serialize, Serializer};
 use self::serde::de::{self, Deserialize, Deserializer, Visitor};
+use self::serde::ser::{Serialize, Serializer};
 
 use super::UuidB64;
 
@@ -44,9 +44,10 @@ impl<'de> Visitor<'de> for UuidB64Visitor {
 
 #[cfg(test)]
 mod tests {
+    use serde_derive::Deserialize;
     use uuid::Uuid;
 
-    use UuidB64;
+    use crate::UuidB64;
 
     #[test]
     fn ser_de() {


### PR DESCRIPTION
I was thinking of using this dependency for a project but saw that it was pretty out of date so I spent a little bit of time cleaning it up.

## Changes
- Migrated to latest edition
- Updated all the dependencies
- Removed `lazy_static` because it is no longer needed with new versions of `base64`
- Fixed the feature flags to be opt-in

## Testing
All the units tests except the ones related to `diesel` pass. I'm getting a link error when I enable the `diesel` feature flag but I assume that they still pass if you compile the binary in the right environment.

## Improved Codegen
I took a look at the asm generated for this snippet on both the current version (`master`) and after these changes to see the difference in codegen:
```rust
// With `lto = true`
#[no_mangle]
#[inline(never)]
pub fn convert(e: UuidB64) -> InlineString {
    e.to_istring()
}
```

On `master` there are lots of branch and allocation calls; meanwhile after updating `base64` the above function now only contains the following instructions on x86:
`add, lea, mov, movabs, movups, movzx, or, ret, shr, sub`

I haven't measured the performance difference with a benchmark but presumably this new version will be much faster.