### PR TITLE
Set a wider range of acceptable base64 versions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,6 +16,10 @@ jobs:
     strategy:
       matrix:
         rust-version: [stable, beta, nightly]
+        base64-version: [""]
+        include:
+          - rust-version: stable
+            base64-version: "0.21"
 
     services:
       postgres:
@@ -42,7 +46,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        run: cargo build --features diesel-uuid,serde
+        run: |
+          if [ -n "${{ matrix.base64-version }}" ] ; then
+            cargo remove base64
+            cargo add base64@${{ matrix.base64-version }}
+          fi
+
+          cargo build --features diesel-uuid,serde
 
       - name: Test
         run: cargo nextest run --features diesel-uuid,serde

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 travis-ci = { repository = "quodlibetor/uuid-b64", branch = "master" }
 
 [dependencies]
-base64 = "0.22.0"
+base64 = ">=0.21.0,<=0.22"
 diesel-derive-newtype = { version = "2.1.0", optional = true }
 diesel = { version = "2.2.0", features = ["postgres", "uuid"], optional = true }
 error-chain = "0.12.0"


### PR DESCRIPTION
This works without change for base64 version 21 or 22, so allow users to specify either